### PR TITLE
Refactor symptom analysis section layout

### DIFF
--- a/src/pages/editar-paciente/[id].astro
+++ b/src/pages/editar-paciente/[id].astro
@@ -298,6 +298,20 @@ const listaExtras = p.pacientes_puntajes_extra || [];
                 </section>
 
                 <section class="w-full max-w-4xl px-2 md:px-0">
+                    <h2 class="section-title">Análisis de síntomas</h2>
+                    <div id="lista-sintomas" class="space-y-8">
+                        {listaSintomas.map((s:any, idx:any) => (
+                            <SintomaGroup numero={idx + 1} data={s} />
+                        ))}
+                    </div>
+                    <div class="mt-4 flex justify-end">
+                        <button type="button" id="btn-add-sintoma" class="flex items-center gap-2 text-sm font-medium text-blue-400 hover:text-white border border-blue-500/30 hover:bg-blue-600/20 px-4 py-2 rounded-lg cursor-pointer">
+                            <span class="text-xl leading-none">+</span> Agregar otro síntoma
+                        </button>
+                    </div>
+                </section>
+
+                <section class="w-full max-w-4xl px-2 md:px-0">
                     <h2 class="section-title">Diagnósticos previos</h2>
                     <textarea name="antecedentes" rows="4" class="input resize-y">{p.antecedentes}</textarea>
                 </section>
@@ -418,20 +432,6 @@ const listaExtras = p.pacientes_puntajes_extra || [];
                             </div>
                             <div id="div_te" class={p.te === 'si' ? "mt-3" : "hidden mt-3"}><label class="sub-label">Tazas/semana</label><input type="number" name="tazas_te_semana" value={p.tazas_te_semana} class="input-sub"></div>
                         </div>
-                    </div>
-                </section>
-
-                <section class="w-full max-w-4xl px-2 md:px-0">
-                    <h2 class="section-title">Análisis de síntomas</h2>
-                    <div id="lista-sintomas" class="space-y-8">
-                        {listaSintomas.map((s:any, idx:any) => (
-                            <SintomaGroup numero={idx + 1} data={s} />
-                        ))}
-                    </div>
-                    <div class="mt-4 flex justify-end">
-                        <button type="button" id="btn-add-sintoma" class="flex items-center gap-2 text-sm font-medium text-blue-400 hover:text-white border border-blue-500/30 hover:bg-blue-600/20 px-4 py-2 rounded-lg cursor-pointer">
-                            <span class="text-xl leading-none">+</span> Agregar otro síntoma
-                        </button>
                     </div>
                 </section>
 

--- a/src/pages/paciente/[id].astro
+++ b/src/pages/paciente/[id].astro
@@ -255,6 +255,26 @@ const edadDisplay = paciente.edad || (paciente.fecha_nacimiento ? new Date().get
 
             </div>
 
+            <InfoCard title="Análisis de Síntomas">
+                {paciente.pacientes_sintomas && paciente.pacientes_sintomas.length > 0 ? (
+                    <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+                        {paciente.pacientes_sintomas.map((s: any, index: number) => (
+                            <div class="bg-gray-800/40 border border-gray-700 p-4 rounded-xl relative group hover:border-blue-500/50 transition-colors">
+                                <div class="absolute -top-2 -right-2 bg-blue-600 text-white text-[10px] px-2 py-0.5 rounded-full font-bold">#{index + 1}</div>
+                                <h4 class="text-lg font-bold text-white mb-2 capitalize">{s.sintoma}</h4>
+                                <div class="space-y-1 text-sm">
+                                    <p><span class="text-gray-500">Temporalidad:</span> <span class="text-gray-300">{s.temporalidad}</span></p>
+                                    <p><span class="text-gray-500">Frecuencia:</span> <span class="text-gray-300">{s.frecuencia}</span></p>
+                                    <p><span class="text-gray-500">Gravedad:</span> <span class="text-gray-300">{s.gravedad}</span></p>
+                                </div>
+                            </div>
+                        ))}
+                    </div>
+                ) : (
+                    <div class="text-gray-500 italic">No hay síntomas registrados.</div>
+                )}
+            </InfoCard>
+
             <InfoCard title="Hábitos y Patrones de Sueño">
     
                 <div class="grid grid-cols-2 md:grid-cols-4 gap-4 mb-8 border-b border-gray-700/50 pb-8">
@@ -317,26 +337,6 @@ const edadDisplay = paciente.edad || (paciente.fecha_nacimiento ? new Date().get
                     </div>
                 </div>
 
-            </InfoCard>
-
-            <InfoCard title="Análisis de Síntomas">
-                {paciente.pacientes_sintomas && paciente.pacientes_sintomas.length > 0 ? (
-                    <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-                        {paciente.pacientes_sintomas.map((s: any, index: number) => (
-                            <div class="bg-gray-800/40 border border-gray-700 p-4 rounded-xl relative group hover:border-blue-500/50 transition-colors">
-                                <div class="absolute -top-2 -right-2 bg-blue-600 text-white text-[10px] px-2 py-0.5 rounded-full font-bold">#{index + 1}</div>
-                                <h4 class="text-lg font-bold text-white mb-2 capitalize">{s.sintoma}</h4>
-                                <div class="space-y-1 text-sm">
-                                    <p><span class="text-gray-500">Temporalidad:</span> <span class="text-gray-300">{s.temporalidad}</span></p>
-                                    <p><span class="text-gray-500">Frecuencia:</span> <span class="text-gray-300">{s.frecuencia}</span></p>
-                                    <p><span class="text-gray-500">Gravedad:</span> <span class="text-gray-300">{s.gravedad}</span></p>
-                                </div>
-                            </div>
-                        ))}
-                    </div>
-                ) : (
-                    <div class="text-gray-500 italic">No hay síntomas registrados.</div>
-                )}
             </InfoCard>
 
             {/* Contenedor opcional

--- a/src/pages/registro.astro
+++ b/src/pages/registro.astro
@@ -331,6 +331,20 @@ if (Astro.request.method === "POST") {
                 </section>
 
                 <section class="w-full max-w-4xl px-2 md:px-0">
+                    <h2 class="text-2xl md:text-3xl pb-2 mb-6 border-b border-white text-center text-gray-200 w-fit mx-auto px-10">Análisis de síntomas</h2>
+                    
+                    <div id="lista-sintomas" class="space-y-8">
+                        <SintomaGroup numero={1} />
+                    </div>
+
+                    <div class="mt-4 flex justify-end">
+                        <button type="button" id="btn-add-sintoma" class="flex items-center gap-2 text-sm font-medium text-blue-400 hover:text-white transition-colors border border-blue-500/30 hover:bg-blue-600/20 px-4 py-2 rounded-lg cursor-pointer">
+                            <span class="text-xl leading-none">+</span> Agregar otro síntoma
+                        </button>
+                    </div>
+                </section>
+
+                <section class="w-full max-w-4xl px-2 md:px-0">
                     <h2 class="text-2xl md:text-3xl pb-2 mb-6 border-b border-white text-center text-gray-200 w-fit mx-auto px-10">Diagnósticos previos</h2>
                     <div class="flex flex-col space-y-4">
                         <div class="flex flex-col">
@@ -485,20 +499,6 @@ if (Astro.request.method === "POST") {
                                 <input type="number" id="tazas_te_semana" name="tazas_te_semana" min="0" class="w-full p-2 border border-blue-500/30 bg-blue-900/10 rounded-lg focus:outline-none focus:ring-1 focus:ring-blue-500 text-white">
                             </div>
                         </div>
-                    </div>
-                </section>
-
-                <section class="w-full max-w-4xl px-2 md:px-0">
-                    <h2 class="text-2xl md:text-3xl pb-2 mb-6 border-b border-white text-center text-gray-200 w-fit mx-auto px-10">Análisis de síntomas</h2>
-                    
-                    <div id="lista-sintomas" class="space-y-8">
-                        <SintomaGroup numero={1} />
-                    </div>
-
-                    <div class="mt-4 flex justify-end">
-                        <button type="button" id="btn-add-sintoma" class="flex items-center gap-2 text-sm font-medium text-blue-400 hover:text-white transition-colors border border-blue-500/30 hover:bg-blue-600/20 px-4 py-2 rounded-lg cursor-pointer">
-                            <span class="text-xl leading-none">+</span> Agregar otro síntoma
-                        </button>
                     </div>
                 </section>
 


### PR DESCRIPTION
Moved the 'Análisis de síntomas' section above previous diagnoses and sleep alterations in editar-paciente/[id].astro and registro.astro for improved form flow.

Also reordered the symptom analysis card in paciente/[id].astro for consistency in patient detail display.