### PR TITLE
Move DB logic to services; add supabase client

### DIFF
--- a/src/components/CitaCard.astro
+++ b/src/components/CitaCard.astro
@@ -6,7 +6,7 @@
 
 interface Props {
     cita: {
-        id: string;
+        id: number;
         nombre: string;
         fecha_hora: string;
         telefono: string | null;

--- a/src/data/changelog.ts
+++ b/src/data/changelog.ts
@@ -6,28 +6,8 @@ export const updateDate = "13 de Marzo del 2026";
 
 export const changes = [
     {
-        title: "Lista de tareas pendientes",
-        description: "Se agregó la funcionalidad para poder crear, asignar y gestionar tareas pendientes del laboratorio.",
+        title: "Recordatorio de tareas pendientes",
+        description: "Se agregó un sidebar fijo en el dashboard que muestra las tareas pendientes del usuario correspondiente",
         type: "feature"
-    },
-    {
-        title: "Días inhabiles",
-        description: "Se agregó la funcionalidad para marcar o desmarcar días inhábiles o vacacionales.",
-        type: "feature"
-    },
-    {
-        title: "Resultados Berlín",
-        description: "Se corrigió un error en donde la tercera categoría no se mostraba correctamente si era positiva.",
-        type: "fix"
-    },
-    {
-        title: "Scroll con modal abierto",
-        description: "Se corrigió un bug en el que la página se desplazaba mientras algún modal estaba abierto.",
-        type: "fix"
-    },
-    {
-        title: "Lista de pacientes",
-        description: "Se redujo la cantidad de pacientes mostrados en la lista.",
-        type: "style"
     }
 ];

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,0 +1,6 @@
+import { createClient } from "@supabase/supabase-js";
+
+export const supabase = createClient(
+    import.meta.env.PUBLIC_SUPABASE_URL,
+    import.meta.env.SUPABASE_KEY
+);

--- a/src/pages/citas.astro
+++ b/src/pages/citas.astro
@@ -9,206 +9,105 @@
  * - Renderizado: Genera una cuadrícula de días reales + días de relleno (padding)
  * para alinear correctamente el primer día del mes (Lunes, Martes, etc.).
  * - Interactividad: Usa <dialog> nativo para ver los detalles de las citas de un día.
+ *
+ * La lógica de acceso a datos vive en: src/services/citas.service.ts
  */
 
 import Layout from "../layouts/Layout.astro"
 import CitaCard from "../components/CitaCard.astro"
 import ReturnButton from "../components/ReturnButton.astro"
-import { createClient } from "@supabase/supabase-js"
-
-// 1. CONFIGURACIÓN
-const supabase = createClient(
-    import.meta.env.PUBLIC_SUPABASE_URL,
-    import.meta.env.SUPABASE_KEY
-);
+import {
+    getCitasDelMes,
+    getDiasInhabilesDelMes,
+    completarCita,
+    cancelarCita,
+    reagendarCita,
+    toggleDiaInhabil,
+    procesarPeriodoInhabil,
+    type CitaResumen,
+} from "../services/citas.service"
 
 const getMeridaDate = () => {
     const d = new Date();
-    const formatter = new Intl.DateTimeFormat('en-US', {
-        timeZone: 'America/Merida',
-        year: 'numeric',
-        month: 'numeric',
-        day: 'numeric'
+    const formatter = new Intl.DateTimeFormat("en-US", {
+        timeZone: "America/Merida",
+        year: "numeric", month: "numeric", day: "numeric",
     });
     const parts = formatter.formatToParts(d);
-    const year = parseInt(parts.find(p => p.type === 'year')?.value || '0');
-    const month = parseInt(parts.find(p => p.type === 'month')?.value || '0') - 1;
-    const day = parseInt(parts.find(p => p.type === 'day')?.value || '0');
+    const year  = parseInt(parts.find(p => p.type === "year")?.value  || "0");
+    const month = parseInt(parts.find(p => p.type === "month")?.value || "0") - 1;
+    const day   = parseInt(parts.find(p => p.type === "day")?.value   || "0");
     return new Date(year, month, day);
 };
 
-const today = getMeridaDate();
-const currentYear = parseInt(Astro.url.searchParams.get('year') || today.getFullYear().toString());
-const currentMonth = parseInt(Astro.url.searchParams.get('month') || today.getMonth().toString());
+const today        = getMeridaDate();
+const currentYear  = parseInt(Astro.url.searchParams.get("year")  || today.getFullYear().toString());
+const currentMonth = parseInt(Astro.url.searchParams.get("month") || today.getMonth().toString());
 
-const monthNames = ["Enero", "Febrero", "Marzo", "Abril", "Mayo", "Junio", "Julio", "Agosto", "Septiembre", "Octubre", "Noviembre", "Diciembre"];
+const monthNames   = ["Enero","Febrero","Marzo","Abril","Mayo","Junio","Julio","Agosto","Septiembre","Octubre","Noviembre","Diciembre"];
 const displayMonth = monthNames[currentMonth];
 
 const firstDayOfMonth = new Date(currentYear, currentMonth, 1).getDay();
-const daysInMonth = new Date(currentYear, currentMonth + 1, 0).getDate();
-const baseYear = new Date().getFullYear();
-const yearsRange = Array.from({ length: 3 }, (_, i) => baseYear - 1 + i);
+const daysInMonth     = new Date(currentYear, currentMonth + 1, 0).getDate();
+const baseYear        = new Date().getFullYear();
+const yearsRange      = Array.from({ length: 3 }, (_, i) => baseYear - 1 + i);
 
 const prevDate = new Date(currentYear, currentMonth - 1, 1);
 const nextDate = new Date(currentYear, currentMonth + 1, 1);
 const prevLink = `?month=${prevDate.getMonth()}&year=${prevDate.getFullYear()}`;
 const nextLink = `?month=${nextDate.getMonth()}&year=${nextDate.getFullYear()}`;
 
-const startDateStr = new Date(currentYear, currentMonth, 1).toISOString();
-const endDateStr = new Date(currentYear, currentMonth + 1, 0, 23, 59, 59).toISOString();
-
 const user = await Astro.locals.currentUser();
-const nombreRegistrador = user 
-    ? `${user.firstName} ${user.lastName}`.trim() || user.username 
+const nombreRegistrador = user
+    ? `${user.firstName} ${user.lastName}`.trim() || user.username
     : "Sistema";
 
-// --- LÓGICA PARA ACTUALIZAR ESTADO ---
 if (Astro.request.method === "POST") {
     try {
-        const data = await Astro.request.formData();
-        const citaId = data.get("id_cita");
-        const accion = data.get("accion");
+        const data   = await Astro.request.formData();
+        const accion = data.get("accion") as string;
+        const citaId = parseInt(data.get("id_cita") as string);
 
-        if (citaId && accion) {
-            if (accion === 'reagendar') {
-                const nuevaFecha = data.get("nueva_fecha") as string;
-                const fechaObj = new Date(`${nuevaFecha}-06:00`);
-                const nuevaFechaISO = fechaObj.toISOString();
-                const fechaSoloDia = nuevaFecha.split('T')[0];
+        if (citaId && accion === "completar") {
+            await completarCita(citaId);
 
-                const { data: diaBloqueado } = await supabase
-                    .from('dias_inhabiles')
-                    .select('fecha')
-                    .eq('fecha', fechaSoloDia)
-                    .single();
+        } else if (citaId && accion === "cancelar") {
+            await cancelarCita(citaId);
 
-                if (diaBloqueado) {
-                    console.warn(`Intento bloqueado: Se intentó reagendar al día inhábil ${fechaSoloDia}`);
-                    return Astro.redirect(Astro.url.href); 
-                }
-                
-                const { data: citaOriginal, error: errorFetch } = await supabase
-                    .from('citas')
-                    .select('*')
-                    .eq('id', citaId)
-                    .single();
+        } else if (citaId && accion === "reagendar") {
+            const nuevaFecha = data.get("nueva_fecha") as string;
+            await reagendarCita(citaId, nuevaFecha, nombreRegistrador as string);
 
-                if (!errorFetch && citaOriginal) {
-                    const { error: insertError } = await supabase
-                        .from('citas')
-                        .insert({
-                            fecha_hora: nuevaFechaISO, 
-                            nombre: citaOriginal.nombre,
-                            telefono: citaOriginal.telefono,
-                            motivo: citaOriginal.motivo,
-                            sintoma: citaOriginal.sintoma,
-                            referencia: citaOriginal.referencia,
-                            atendido_por: citaOriginal.atendido_por,
-                            observaciones: citaOriginal.observaciones,
-                            estado: 'pendiente', 
-                            registrado_por_id: nombreRegistrador 
-                        });
+        } else if (accion === "toggle_inhabil") {
+            const fecha     = data.get("fecha")      as string;
+            const esInhabil = data.get("es_inhabil") === "true";
+            await toggleDiaInhabil(fecha, esInhabil);
 
-                    if (!insertError) {
-                        const fechaTexto = fechaObj.toLocaleString('es-MX', { 
-                            timeZone: 'America/Merida',
-                            year: 'numeric', month: 'numeric', day: 'numeric',
-                            hour: '2-digit', minute: '2-digit', hour12: true
-                        });
-
-                        const notaReagenda = `\n[Cita reagendada para el: ${fechaTexto} por ${nombreRegistrador}]`;
-                        
-                        await supabase
-                            .from('citas')
-                            .update({ 
-                                estado: 'cancelada',
-                                observaciones: (citaOriginal.observaciones || '') + notaReagenda
-                            })
-                            .eq('id', citaId);
-                            
-                        return Astro.redirect(Astro.url.href);
-                    }
-                }
-            } else {
-                const nuevoEstado = accion === 'completar' ? 'completada' : 'cancelada';
-                await supabase.from('citas').update({ estado: nuevoEstado }).eq('id', citaId);
-            }
-        }
-
-        if (accion === 'toggle_inhabil') {
-            const fechaInhabil = data.get("fecha") as string;
-            const esInhabilStr = data.get("es_inhabil");
-
-            if (esInhabilStr === 'true') {
-                await supabase.from('dias_inhabiles').delete().eq('fecha', fechaInhabil);
-            } else {
-                await supabase.from('dias_inhabiles').insert({ fecha: fechaInhabil });
-            }
-            return Astro.redirect(Astro.url.href);
-        }
-
-        if (accion === 'procesar_periodo') {
-            const fechaInicio = data.get("fecha_inicio") as string;
-            const fechaFin = data.get("fecha_fin") as string;
-            const tipoOperacion = data.get("tipo_operacion") as string;
-
-            if (fechaInicio && fechaFin) {
-                const start = new Date(`${fechaInicio}T12:00:00`);
-                const end = new Date(`${fechaFin}T12:00:00`);
-                const fechasProcesar = [];
-
-                for (let d = new Date(start); d <= end; d.setDate(d.getDate() + 1)) {
-                    fechasProcesar.push(d.toISOString().split('T')[0]);
-                }
-
-                if (fechasProcesar.length > 0) {
-                    if (tipoOperacion === 'bloquear') {
-                        const insertData = fechasProcesar.map(f => ({ fecha: f }));
-                        await supabase.from('dias_inhabiles').upsert(insertData, { onConflict: 'fecha' });
-                    } else if (tipoOperacion === 'habilitar') {
-                        await supabase.from('dias_inhabiles').delete().in('fecha', fechasProcesar);
-                    }
-                }
-            }
-            return Astro.redirect(Astro.url.href);
+        } else if (accion === "procesar_periodo") {
+            const fechaInicio    = data.get("fecha_inicio")    as string;
+            const fechaFin       = data.get("fecha_fin")       as string;
+            const tipoOperacion  = data.get("tipo_operacion")  as "bloquear" | "habilitar";
+            await procesarPeriodoInhabil(fechaInicio, fechaFin, tipoOperacion);
         }
 
     } catch (e) {
-        console.error("Error procesando cita:", e);
+        console.error("Error procesando acción en citas:", e);
     }
+
+    return Astro.redirect(Astro.url.href);
 }
 
-const [citasResponse, inhabilesResponse] = await Promise.all([
-    supabase
-        .from('citas')
-        .select('id, fecha_hora, nombre, estado, referencia, sintoma, telefono, motivo, atendido_por, observaciones') 
-        .gte('fecha_hora', startDateStr)
-        .lte('fecha_hora', endDateStr)
-        .order('fecha_hora', { ascending: true }),
-    
-    supabase
-        .from('dias_inhabiles')
-        .select('fecha')
-        .gte('fecha', startDateStr.split('T')[0])
-        .lte('fecha', endDateStr.split('T')[0])
+const [citasRaw, diasInhabilesSet] = await Promise.all([
+    getCitasDelMes(currentYear, currentMonth),
+    getDiasInhabilesDelMes(currentYear, currentMonth),
 ]);
 
-const { data: citasRaw, error } = citasResponse;
-const { data: inhabilesRaw } = inhabilesResponse;
+const citasPorDia = new Map<number, CitaResumen[]>();
 
-if (error) console.error("Error fetching citas:", error);
-
-const diasInhabilesSet = new Set(inhabilesRaw?.map(d => d.fecha) || []);
-const citasPorDia = new Map();
-
-citasRaw?.forEach((cita) => {
-    const fecha = new Date(cita.fecha_hora);
-    const dia = fecha.getDate(); 
-    
-    if (!citasPorDia.has(dia)) {
-        citasPorDia.set(dia, []);
-    }
-    citasPorDia.get(dia).push(cita);
+citasRaw.forEach(cita => {
+    const dia = new Date(cita.fecha_hora).getDate();
+    if (!citasPorDia.has(dia)) citasPorDia.set(dia, []);
+    citasPorDia.get(dia)!.push(cita);
 });
 ---
 
@@ -295,12 +194,12 @@ citasRaw?.forEach((cita) => {
                 ))}
 
                 {Array.from({ length: daysInMonth }).map((_, i) => {
-                    const dayNum = i + 1;
+                    const dayNum   = i + 1;
                     const citasDia = citasPorDia.get(dayNum) || [];
-                    const isToday = dayNum === today.getDate() && currentMonth === today.getMonth() && currentYear === today.getFullYear();
+                    const isToday  = dayNum === today.getDate() && currentMonth === today.getMonth() && currentYear === today.getFullYear();
                     
-                    const m = String(currentMonth + 1).padStart(2, '0');
-                    const d = String(dayNum).padStart(2, '0');
+                    const m        = String(currentMonth + 1).padStart(2, "0");
+                    const d        = String(dayNum).padStart(2, "0");
                     const fechaISO = `${currentYear}-${m}-${d}`;
                     const isInhabil = diasInhabilesSet.has(fechaISO);
                     
@@ -333,12 +232,12 @@ citasRaw?.forEach((cita) => {
                             </div>
 
                             <div class="space-y-1 mt-2 z-10">
-                                {citasDia.slice(0, 2).map((cita: any) => (
+                                {citasDia.slice(0, 2).map((cita) => (
                                     <div class={`flex items-center gap-1.5 text-[10px] rounded px-1.5 py-1 backdrop-blur-sm border truncate 
                                         ${isInhabil ? 'bg-red-900/40 border-red-500/10 text-red-300/70' : 'bg-gray-900/40 border-white/5 text-gray-300'}`}>
                                         <div class={`w-1.5 h-1.5 rounded-full flex-shrink-0 ${
                                             cita.estado === 'completada' ? 'bg-emerald-400' : 
-                                            cita.estado === 'cancelada' ? 'bg-red-400' : 'bg-amber-400'
+                                            cita.estado === 'cancelada'  ? 'bg-red-400'     : 'bg-amber-400'
                                         }`}></div>
                                         <span class="truncate opacity-90">{cita.nombre ? cita.nombre.split(' ')[0] : 'Cita'}</span>
                                     </div>
@@ -355,15 +254,15 @@ citasRaw?.forEach((cita) => {
         </div>
     </main>
 
-    <dialog id="citas-store" class="hidden" style="content-visibility: auto;">
+    <div id="citas-store" class="hidden" style="content-visibility: auto;">
         {Array.from(citasPorDia.entries()).map(([dia, citas]) => (
             <div data-day={dia} class="space-y-4">
-                {citas.map((cita: any) => (
+                {citas.map((cita) => (
                     <CitaCard cita={cita} />
                 ))}
             </div>
         ))}
-    </dialog>
+    </div>
 
     <dialog id="modal-periodo" class="m-auto bg-gray-900 border border-gray-700 rounded-3xl shadow-2xl backdrop:backdrop-blur-xl w-full max-w-md text-left p-0 overflow-hidden outline-none">
         <div class="relative bg-gray-800/30 p-6 border-b border-gray-700/50 flex justify-between items-center">

--- a/src/pages/dashboard.astro
+++ b/src/pages/dashboard.astro
@@ -2,133 +2,65 @@
 /**
  * @file dashboard.astro
  * @description Panel de control principal del usuario.
- * OPTIMIZACIÓN: Se implementó Promise.all para cargar usuarios y citas en paralelo.
+ *
+ * La lógica de acceso a datos vive en: src/services/dashboard.service.ts
  */
 
 import Layout from "../layouts/Layout.astro"
-import { createClient } from "@supabase/supabase-js"
 import { UserButton } from "@clerk/astro/components";
-import { clerkClient } from "@clerk/astro/server";
 import SystemUpdates from "../components/SystemUpdate.astro";
 import PatientTypeModal from "../components/PatientTypeModal.astro";
 import ExternalLinkIcon from "../components/icons/ExternalLinkIcon.astro";
+import {
+    getCitasHoy,
+    getNotificaciones,
+    getUsuariosRecientes,
+    marcarTodasLeidas,
+} from "../services/dashboard.service";
+import {
+    getTareasDeUsuario,
+    completarTarea,
+} from "../services/lista-pendientes.service";
 
-const user = await Astro.locals.currentUser();
+const user          = await Astro.locals.currentUser();
 const nombreUsuario = user?.firstName || user?.username || "Usuario";
-
-const supabase = createClient(
-    import.meta.env.PUBLIC_SUPABASE_URL,
-    import.meta.env.SUPABASE_KEY
-);
-const client = clerkClient(Astro);
-
-const now = new Date();
-const offsetMerida = 6 * 60 * 60 * 1000; 
-const nowMerida = new Date(now.getTime() - offsetMerida);
-const year = nowMerida.getUTCFullYear();
-const month = String(nowMerida.getUTCMonth() + 1).padStart(2, '0');
-const day = String(nowMerida.getUTCDate()).padStart(2, '0');
-const fechaSQL = `${year}-${month}-${day}`;
-const inicioDia = `${fechaSQL}T00:00:00-06:00`;
-const finDia = `${fechaSQL}T23:59:59-06:00`;
-
-const usersPromise = (async () => {
-    try {
-        const response = await client.users.getUserList({
-            limit: 10,
-            orderBy: '-last_active_at'
-        });
-        return Array.isArray(response) ? response : (response.data || []);
-    } catch (e) {
-        console.error("Error usuarios:", e);
-        return [];
-    }
-})();
-
-const citasPromise = supabase
-    .from('citas')
-    .select('id, fecha_hora, nombre, estado') 
-    .gte('fecha_hora', inicioDia)
-    .lte('fecha_hora', finDia)
-    .order('fecha_hora', { ascending: true });
-
-const notificacionesPromise = supabase
-    .from('respuestas_cuestionarios')
-    .select(`
-        id,
-        cuestionario,
-        updated_at,
-        pacientes ( id, nombre, tipo_paciente )
-    `)
-    .eq('visto', false)
-    .order('updated_at', { ascending: false })
-    .limit(10);
+const nombreCompleto = user
+    ? `${user.firstName || ""} ${user.lastName || ""}`.trim() || user.username || ""
+    : "";
 
 
-const [usuariosRecientes, citasResult, notificacionesResult] = await Promise.all([
-    usersPromise, 
-    citasPromise, 
-    notificacionesPromise
-]);
-
-const { data: dataCitas, error } = citasResult;
-if (error) console.error("Error Dashboard:", error);
-
-const notificaciones = notificacionesResult.data || [];
-const hayNotificaciones = notificaciones.length > 0;
-
-
-const citasHoy = dataCitas || [];
-const totalCitasHoy = citasHoy.length;
-const citasPendientes = citasHoy.filter(c => c.estado === 'pendiente');
-const cantidadPendientes = citasPendientes.length;
-
-let proximaHora = "--:--";
-let proximaNombre = "";
-let estadoAgenda = "vacio";
-
-if (cantidadPendientes > 0) {
-    const siguiente = citasPendientes[0];
-    estadoAgenda = "pendiente";
-    proximaNombre = siguiente.nombre || "Paciente";
-    
-    if (siguiente.fecha_hora) {
-        const dateObj = new Date(siguiente.fecha_hora);
-        proximaHora = dateObj.toLocaleTimeString('es-MX', { 
-            hour: '2-digit', minute: '2-digit', hour12: false, timeZone: 'America/Merida'
-        });
-    }
-} else if (totalCitasHoy > 0) {
-    estadoAgenda = "completado";
-    proximaNombre = "Todas las citas finalizadas";
-}
-
-// --- MARCAR TODO COMO VISTO ---
 if (Astro.request.method === "POST") {
     try {
         const formData = await Astro.request.formData();
-        const action = formData.get("action");
+        const action   = formData.get("action");
 
         if (action === "mark_all_read") {
-            // Actualizamos TODAS las notificaciones no vistas a true
-            const { error } = await supabase
-                .from('respuestas_cuestionarios')
-                .update({ visto: true })
-                .eq('visto', false);
-            
-            if (!error) {
-                // Recargamos para limpiar la UI
-                return Astro.redirect(Astro.url.href);
-            }
+            await marcarTodasLeidas();
+        }
+
+        if (action === "completar_tarea_sidebar") {
+            const idTarea = parseInt(formData.get("id_tarea") as string);
+            await completarTarea(idTarea, nombreCompleto as string);
         }
     } catch (e) {
         console.error("Error marcando notificaciones:", e);
     }
+    return Astro.redirect(Astro.url.href);
 }
 
-const fechaHoyTexto = new Date().toLocaleDateString('es-MX', { 
-    timeZone: 'America/Merida',
-    weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' 
+const [agenda, notificaciones, usuariosRecientes, tareasUsuario] = await Promise.all([
+    getCitasHoy(),
+    getNotificaciones(),
+    getUsuariosRecientes(Astro),
+    getTareasDeUsuario(nombreCompleto as string),
+]);
+
+const { totalCitasHoy, cantidadPendientes, estadoAgenda, proximaHora, proximaNombre } = agenda;
+const hayNotificaciones = notificaciones.length > 0;
+
+const fechaHoyTexto = new Date().toLocaleDateString("es-MX", {
+    timeZone: "America/Merida",
+    weekday: "long", year: "numeric", month: "long", day: "numeric",
 });
 ---
 
@@ -168,7 +100,6 @@ const fechaHoyTexto = new Date().toLocaleDateString('es-MX', {
                             Abrir Lab-Somno App <ExternalLinkIcon class="w-4 h-4 ml-1 text-teal-400" />
                         </span>
                     </a>
-
                 </div>
 
                 <div class="hidden md:flex flex-col items-end gap-4 text-right">
@@ -236,7 +167,7 @@ const fechaHoyTexto = new Date().toLocaleDateString('es-MX', {
                                 </div>
                                 <div class="max-h-64 overflow-y-auto py-1 custom-scrollbar text-left">
                                     {hayNotificaciones ? (
-                                        notificaciones.map((notif: any) => (
+                                        notificaciones.map((notif) => (
                                             <a 
                                                 href={`/paciente/${notif.pacientes?.tipo_paciente || 'sueno'}/${notif.pacientes?.id}?marcar_leido=${notif.id}#evaluacion`}
                                                 class="block px-4 py-3 hover:bg-white/5 border-b border-gray-800/50 last:border-0 transition-colors"
@@ -279,7 +210,6 @@ const fechaHoyTexto = new Date().toLocaleDateString('es-MX', {
 
         <div class="mb-10 animate-fade-in-up">
             {totalCitasHoy > 0 ? (
-                // CASO A: HAY CITAS HOY (Pendientes o Terminadas)
                 <div class={`relative overflow-hidden rounded-2xl border p-6 flex flex-col md:flex-row items-center justify-between gap-6 shadow-lg transition-all duration-500 ${
                     estadoAgenda === 'completado' 
                         ? 'bg-gradient-to-r from-emerald-900/40 to-teal-900/40 border-emerald-500/30 shadow-emerald-900/10' 
@@ -352,7 +282,6 @@ const fechaHoyTexto = new Date().toLocaleDateString('es-MX', {
                     </div>
                 </div>
             ) : (
-                // CASO B: NO HAY CITAS (Día Libre)
                 <div class="relative overflow-hidden rounded-2xl bg-gray-800/40 border border-gray-700/50 p-6 flex flex-col md:flex-row items-center justify-between gap-4">
                     <div class="flex items-center gap-5">
                         <div class="w-14 h-14 rounded-2xl bg-emerald-500/10 flex items-center justify-center border border-emerald-500/20">
@@ -545,6 +474,69 @@ const fechaHoyTexto = new Date().toLocaleDateString('es-MX', {
         </div>
 
     </main>
+
+    <aside class="hidden xl:block absolute top-28 right-12 w-64 z-40">
+        <div class="bg-gray-900/70 border border-white/8 backdrop-blur-md rounded-2xl overflow-hidden shadow-2xl shadow-black/40">
+            <!-- Header -->
+            <div class="flex items-center justify-between px-4 py-3 border-b border-white/5">
+                <div class="flex items-center gap-2">
+                    <div class="w-1.5 h-1.5 rounded-full bg-amber-400 shadow-[0_0_6px_rgba(251,191,36,0.8)]"></div>
+                    <span class="text-[11px] font-bold text-gray-300 uppercase tracking-widest">Mis tareas</span>
+                    {tareasUsuario.length > 0 && (
+                        <span class="text-[10px] font-bold bg-amber-500/15 text-amber-400 border border-amber-500/20 px-1.5 py-0.5 rounded-full">
+                            {tareasUsuario.length}
+                        </span>
+                    )}
+                </div>
+                <a href="/pendientes/lista-pendientes" class="text-[10px] font-bold text-gray-500 hover:text-blue-400 transition-colors uppercase tracking-wider">
+                    Ver todas
+                </a>
+            </div>
+            {tareasUsuario.length > 0 ? (
+                <div class="flex flex-col divide-y divide-white/5">
+                    {tareasUsuario.map((tarea) => (
+                        <div class="group flex items-center gap-3 px-4 py-3 hover:bg-white/4 transition-colors duration-150">
+                            <!-- Check button -->
+                            <form method="POST" class="m-0 shrink-0">
+                                <input type="hidden" name="action" value="completar_tarea_sidebar" />
+                                <input type="hidden" name="id_tarea" value={tarea.id} />
+                                <button
+                                    type="submit"
+                                    title="Marcar como completada"
+                                    class="w-4 h-4 rounded-full border border-gray-600 group-hover:border-emerald-500 hover:bg-emerald-500/15 flex items-center justify-center transition-all duration-150 cursor-pointer shrink-0"
+                                >
+                                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="w-2.5 h-2.5 text-transparent group-hover:text-emerald-400 transition-colors">
+                                        <path fill-rule="evenodd" d="M16.704 4.153a.75.75 0 0 1 .143 1.052l-8 10.5a.75.75 0 0 1-1.127.075l-4.5-4.5a.75.75 0 0 1 1.06-1.06l3.894 3.893 7.48-9.817a.75.75 0 0 1 1.05-.143Z" clip-rule="evenodd" />
+                                    </svg>
+                                </button>
+                            </form>
+                            <p class="text-xs text-gray-400 group-hover:text-gray-200 transition-colors leading-snug line-clamp-2 flex-1 min-w-0">
+                                {tarea.titulo}
+                            </p>
+                        </div>
+                    ))}
+                </div>
+            ) : (
+                <div class="flex flex-col items-center justify-center gap-2 py-8 px-4 text-center">
+                    <div class="w-8 h-8 rounded-full bg-emerald-500/10 border border-emerald-500/15 flex items-center justify-center">
+                        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" class="w-4 h-4 text-emerald-400">
+                            <path stroke-linecap="round" stroke-linejoin="round" d="M4.5 12.75l6 6 9-13.5" />
+                        </svg>
+                    </div>
+                    <p class="text-xs font-medium text-gray-500">¡Sin pendientes!</p>
+                </div>
+            )}
+            <div class="px-4 py-3 border-t border-white/5">
+                <a
+                    href="/pendientes/lista-pendientes"
+                    class="flex items-center justify-center gap-1.5 w-full py-2 rounded-lg bg-white/4 hover:bg-white/8 border border-white/6 hover:border-white/10 text-[11px] font-semibold text-gray-500 hover:text-gray-300 transition-all duration-150"
+                >
+                    Ver todas las tareas
+                </a>
+            </div>
+        </div>
+    </aside>
+
     <SystemUpdates />
     <PatientTypeModal />
 </Layout>
@@ -557,7 +549,6 @@ const fechaHoyTexto = new Date().toLocaleDateString('es-MX', {
     .animate-infinite-scroll {
         animation: scroll 20s linear infinite;
     }
-    /* Pausar al pasar el mouse para ver detalles */
     .animate-infinite-scroll:hover {
         animation-play-state: paused;
     }

--- a/src/pages/pendientes/lista-pendientes.astro
+++ b/src/pages/pendientes/lista-pendientes.astro
@@ -2,96 +2,71 @@
 /**
  * @file pendientes.astro
  * @description Módulo de tareas y pendientes del laboratorio.
+ *
+ * La lógica de acceso a datos vive en: src/services/pendientes.service.ts
  */
 
 import Layout from "../../layouts/Layout.astro"
 import ReturnButton from "../../components/ReturnButton.astro"
-import { createClient } from "@supabase/supabase-js"
 import { clerkClient } from "@clerk/astro/server"
+import { getTareasPendientes, crearTarea, completarTarea } from "../../services/lista-pendientes.service"
 
-// 1. CONFIGURACIÓN SUPABASE
-const supabase = createClient(
-    import.meta.env.PUBLIC_SUPABASE_URL,
-    import.meta.env.SUPABASE_KEY
-);
-
-// 2. OBTENER USUARIO ACTUAL Y LISTA DEL PERSONAL (CLERK)
 const currentUser = await Astro.locals.currentUser();
-const nombreCreador = currentUser 
-    ? `${currentUser.firstName || ''} ${currentUser.lastName || ''}`.trim() || currentUser.username 
+const nombreCreador = currentUser
+    ? `${currentUser.firstName || ""} ${currentUser.lastName || ""}`.trim() || currentUser.username
     : "Sistema";
 
-// Obtenemos todos los usuarios de Clerk
 const userList = await clerkClient(Astro).users.getUserList();
-
 
 const listaPersonal: string[] = [];
 const mapaAvatares: Record<string, string> = {};
+
 userList.data.forEach(u => {
-    const nombre = `${u.firstName || ''} ${u.lastName || ''}`.trim() || u.username;
+    const nombre = `${u.firstName || ""} ${u.lastName || ""}`.trim() || u.username;
     if (nombre) {
         listaPersonal.push(nombre);
-        mapaAvatares[nombre] = u.imageUrl; // Guardamos la foto de Clerk
+        mapaAvatares[nombre] = u.imageUrl;
     }
 });
 
-// 3. PROCESAR FORMULARIOS (CREAR O COMPLETAR TAREA)
 if (Astro.request.method === "POST") {
     try {
-        const data = await Astro.request.formData();
+        const data   = await Astro.request.formData();
         const accion = data.get("accion");
 
         if (accion === "crear_tarea") {
-            const titulo = data.get("titulo") as string;
-            const descripcion = data.get("descripcion") as string;
-            const responsable = data.get("responsable") as string;
-
-            await supabase.from('tareas_pendientes').insert({
-                titulo,
-                descripcion,
-                responsable,
-                creado_por: nombreCreador,
-                estado: 'pendiente'
+            await crearTarea({
+                titulo:      data.get("titulo")      as string,
+                descripcion: data.get("descripcion") as string,
+                responsable: data.get("responsable") as string,
+                creadoPor:   nombreCreador as string,
             });
-            
-            return Astro.redirect('/pendientes/lista-pendientes');
         }
 
         if (accion === "completar_tarea") {
-            const idTarea = data.get("id_tarea");
-            
-            await supabase.from('tareas_pendientes').update({ 
-                estado: 'completada',
-                completado_por: nombreCreador,
-                completado_el: new Date().toISOString()
-            }).eq('id', idTarea);
-            
-            return Astro.redirect('/pendientes/lista-pendientes');
+            const idTarea = parseInt(data.get("id_tarea") as string);
+            await completarTarea(idTarea, nombreCreador as string);
         }
+
     } catch (error) {
         console.error("Error procesando tarea:", error);
     }
+
+    return Astro.redirect("/pendientes/lista-pendientes");
 }
 
-// 4. OBTENER TAREAS PENDIENTES
-const { data: tareas, error } = await supabase
-    .from('tareas_pendientes')
-    .select('*')
-    .eq('estado', 'pendiente')
-    .order('creado_el', { ascending: false });
-
-if (error) console.error("Error fetching tareas:", error);
+const tareas = await getTareasPendientes();
 
 const getInitials = (name: string) => {
-    if (!name) return '?';
-    const words = name.trim().split(' ');
+    if (!name) return "?";
+    const words = name.trim().split(" ");
     if (words.length >= 2) return (words[0][0] + words[1][0]).toUpperCase();
     return name.substring(0, 2).toUpperCase();
 };
 
 const formatCorto = (fechaStr: string) => {
-    if (!fechaStr) return '';
-    return new Date(fechaStr).toLocaleDateString('es-MX', { month: 'short', day: 'numeric' });
+    if (!fechaStr) return "";
+    return new Date(fechaStr).toLocaleDateString("es-MX", { month: "short", day: "numeric" });
 };
 ---
 
@@ -121,7 +96,7 @@ const formatCorto = (fechaStr: string) => {
             </div>
         </div>
 
-        {tareas && tareas.length > 0 ? (
+        {tareas.length > 0 ? (
             <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
                 {tareas.map((tarea) => (
                     <div class="bg-slate-900 backdrop-blur-sm border border-gray-700/50 rounded-2xl p-5 hover:bg-gray-800/90 hover:border-blue-500/50 transition-all duration-300 shadow-lg hover:shadow-blue-900/20 flex flex-col h-full relative group hover:-translate-y-1">
@@ -137,7 +112,7 @@ const formatCorto = (fechaStr: string) => {
                         </div>
 
                         <p class="text-gray-400 text-sm mb-6 flex-grow text-pretty whitespace-pre-wrap line-clamp-3 group-hover:line-clamp-none transition-all">
-                            {tarea.descripcion || 'Sin descripción adicional.'}
+                            {tarea.descripcion || "Sin descripción adicional."}
                         </p>
 
                         <div class="flex items-center justify-between mt-auto mb-5 pt-4 border-t border-gray-700/50">

--- a/src/services/citas.service.ts
+++ b/src/services/citas.service.ts
@@ -1,0 +1,180 @@
+/**
+ * @file citas.service.ts
+ * @description Capa de acceso a datos para citas y días inhábiles.
+ * Toda consulta o mutación relacionada con estas tablas pasa por aquí.
+ */
+
+import { supabase } from "../lib/supabase";
+
+export interface Cita {
+    id: number;
+    nombre: string;
+    fecha_hora: string;
+    telefono: string | null;
+    referencia: string;
+    sintoma: string | null;
+    observaciones: string | null;
+    registrado_por_id: string | null;
+    motivo: string | null;
+    estado: 'pendiente' | 'completada' | 'cancelada' | null;
+    atendido_por: string | null;
+}
+
+export type CitaResumen = Pick<Cita,
+    | "id"
+    | "fecha_hora"
+    | "nombre"
+    | "estado"
+    | "referencia"
+    | "sintoma"
+    | "telefono"
+    | "motivo"
+    | "atendido_por"
+    | "observaciones"
+    | "registrado_por_id"
+    
+>;
+
+export async function getCitasDelMes(year: number, month: number): Promise<CitaResumen[]> {
+    const startDateStr = new Date(year, month, 1).toISOString();
+    const endDateStr   = new Date(year, month + 1, 0, 23, 59, 59).toISOString();
+
+    const { data, error } = await supabase
+        .from("citas")
+        .select("id, fecha_hora, nombre, estado, referencia, sintoma, telefono, motivo, atendido_por, observaciones, registrado_por_id")
+        .gte("fecha_hora", startDateStr)
+        .lte("fecha_hora", endDateStr)
+        .order("fecha_hora", { ascending: true });
+
+    if (error) console.error("getCitasDelMes:", error);
+    return data ?? [];
+}
+
+export async function getDiasInhabilesDelMes(year: number, month: number): Promise<Set<string>> {
+    const startDate = new Date(year, month, 1).toISOString().split("T")[0];
+    const endDate   = new Date(year, month + 1, 0).toISOString().split("T")[0];
+
+    const { data } = await supabase
+        .from("dias_inhabiles")
+        .select("fecha")
+        .gte("fecha", startDate)
+        .lte("fecha", endDate);
+
+    return new Set(data?.map(d => d.fecha) ?? []);
+}
+
+async function esDiaInhabil(fechaISO: string): Promise<boolean> {
+    const { data } = await supabase
+        .from("dias_inhabiles")
+        .select("fecha")
+        .eq("fecha", fechaISO)
+        .single();
+
+    return !!data;
+}
+
+export async function completarCita(citaId: number): Promise<void> {
+    const { error } = await supabase
+        .from("citas")
+        .update({ estado: "completada" })
+        .eq("id", citaId);
+
+    if (error) throw new Error(`completarCita: ${error.message}`);
+}
+
+export async function cancelarCita(citaId: number): Promise<void> {
+    const { error } = await supabase
+        .from("citas")
+        .update({ estado: "cancelada" })
+        .eq("id", citaId);
+
+    if (error) throw new Error(`cancelarCita: ${error.message}`);
+}
+
+export async function reagendarCita(
+    citaId: number,
+    nuevaFechaLocal: string,
+    registradoPor: string
+): Promise<void> {
+    const fechaSoloDia = nuevaFechaLocal.split("T")[0];
+
+    if (await esDiaInhabil(fechaSoloDia)) {
+        throw new Error(`El día ${fechaSoloDia} está marcado como inhábil.`);
+    }
+
+    const { data: original, error: errorFetch } = await supabase
+        .from("citas")
+        .select("nombre, telefono, motivo, sintoma, referencia, atendido_por, observaciones")
+        .eq("id", citaId)
+        .single();
+
+    if (errorFetch || !original) throw new Error("No se encontró la cita original.");
+
+    const fechaObj     = new Date(`${nuevaFechaLocal}-06:00`);
+    const nuevaFechaISO = fechaObj.toISOString();
+
+    const { error: insertError } = await supabase.from("citas").insert({
+        nombre:            original.nombre,
+        telefono:          original.telefono,
+        motivo:            original.motivo,
+        sintoma:           original.sintoma,
+        referencia:        original.referencia,
+        atendido_por:      original.atendido_por,
+        observaciones:     original.observaciones,
+        fecha_hora:        nuevaFechaISO,
+        estado:            "pendiente",
+        registrado_por_id: registradoPor,
+    });
+
+    if (insertError) throw new Error(`reagendarCita (insert): ${insertError.message}`);
+
+    const fechaTexto = fechaObj.toLocaleString("es-MX", {
+        timeZone: "America/Merida",
+        year: "numeric", month: "numeric", day: "numeric",
+        hour: "2-digit", minute: "2-digit", hour12: true,
+    });
+
+    const nota = `\n[Cita reagendada para el: ${fechaTexto} por ${registradoPor}]`;
+
+    const { error: updateError } = await supabase
+        .from("citas")
+        .update({
+            estado:        "cancelada",
+            observaciones: (original.observaciones ?? "") + nota,
+        })
+        .eq("id", citaId);
+
+    if (updateError) throw new Error(`reagendarCita (update): ${updateError.message}`);
+}
+
+export async function toggleDiaInhabil(fecha: string, esInhabil: boolean): Promise<void> {
+    if (esInhabil) {
+        await supabase.from("dias_inhabiles").delete().eq("fecha", fecha);
+    } else {
+        await supabase.from("dias_inhabiles").insert({ fecha });
+    }
+}
+
+export async function procesarPeriodoInhabil(
+    fechaInicio: string,
+    fechaFin: string,
+    operacion: "bloquear" | "habilitar"
+): Promise<void> {
+    const start = new Date(`${fechaInicio}T12:00:00`);
+    const end   = new Date(`${fechaFin}T12:00:00`);
+
+    const fechas: string[] = [];
+    for (const d = new Date(start); d <= end; d.setDate(d.getDate() + 1)) {
+        fechas.push(d.toISOString().split("T")[0]);
+    }
+
+    if (fechas.length === 0) return;
+
+    if (operacion === "bloquear") {
+        await supabase
+            .from("dias_inhabiles")
+            .upsert(fechas.map(f => ({ fecha: f })), { onConflict: "fecha" });
+    } else {
+        await supabase.from("dias_inhabiles").delete().in("fecha", fechas);
+    }
+}

--- a/src/services/dashboard.service.ts
+++ b/src/services/dashboard.service.ts
@@ -1,0 +1,136 @@
+/**
+ * @file dashboard.service.ts
+ * @description Capa de acceso a datos para el panel de control.
+ * Cubre tres fuentes: citas del día (Supabase), notificaciones de
+ * cuestionarios respondidos (Supabase) y usuarios recientes (Clerk).
+ */
+
+import { clerkClient } from "@clerk/astro/server";
+import { supabase } from "../lib/supabase";
+
+export interface CitaResumen {
+    id: number;
+    fecha_hora: string;
+    nombre: string;
+    estado: "pendiente" | "completada" | "cancelada" | null;
+}
+
+export interface PacienteRelacion {
+    id: number;
+    nombre: string;
+    tipo_paciente: string;
+}
+
+export interface Notificacion {
+    id: number;
+    cuestionario: string;
+    updated_at: string;
+    pacientes: PacienteRelacion | null;
+}
+
+export interface ResumenAgenda {
+    citasHoy: CitaResumen[];
+    totalCitasHoy: number;
+    cantidadPendientes: number;
+    estadoAgenda: "vacio" | "pendiente" | "completado";
+    proximaHora: string;
+    proximaNombre: string;
+}
+
+function getRangoHoy(): { inicioDia: string; finDia: string } {
+    const now = new Date();
+    const offsetMerida = 6 * 60 * 60 * 1000;
+    const nowMerida = new Date(now.getTime() - offsetMerida);
+
+    const year  = nowMerida.getUTCFullYear();
+    const month = String(nowMerida.getUTCMonth() + 1).padStart(2, "0");
+    const day   = String(nowMerida.getUTCDate()).padStart(2, "0");
+    const fecha = `${year}-${month}-${day}`;
+
+    return {
+        inicioDia: `${fecha}T00:00:00-06:00`,
+        finDia:    `${fecha}T23:59:59-06:00`,
+    };
+}
+
+export async function getCitasHoy(): Promise<ResumenAgenda> {
+    const { inicioDia, finDia } = getRangoHoy();
+
+    const { data, error } = await supabase
+        .from("citas")
+        .select("id, fecha_hora, nombre, estado")
+        .gte("fecha_hora", inicioDia)
+        .lte("fecha_hora", finDia)
+        .order("fecha_hora", { ascending: true });
+
+    if (error) console.error("getCitasHoy:", error);
+
+    const citasHoy          = (data ?? []) as CitaResumen[];
+    const totalCitasHoy     = citasHoy.length;
+    const citasPendientes   = citasHoy.filter(c => c.estado === "pendiente");
+    const cantidadPendientes = citasPendientes.length;
+
+    let estadoAgenda: ResumenAgenda["estadoAgenda"] = "vacio";
+    let proximaHora   = "--:--";
+    let proximaNombre = "";
+
+    if (cantidadPendientes > 0) {
+        estadoAgenda  = "pendiente";
+        const siguiente = citasPendientes[0];
+        proximaNombre = siguiente.nombre || "Paciente";
+        proximaHora   = new Date(siguiente.fecha_hora).toLocaleTimeString("es-MX", {
+            hour: "2-digit", minute: "2-digit", hour12: false, timeZone: "America/Merida",
+        });
+    } else if (totalCitasHoy > 0) {
+        estadoAgenda  = "completado";
+        proximaNombre = "Todas las citas finalizadas";
+    }
+
+    return { citasHoy, totalCitasHoy, cantidadPendientes, estadoAgenda, proximaHora, proximaNombre };
+}
+
+export async function getNotificaciones(): Promise<Notificacion[]> {
+    const { data, error } = await supabase
+        .from("respuestas_cuestionarios")
+        .select(`
+            id,
+            cuestionario,
+            updated_at,
+            pacientes ( id, nombre, tipo_paciente )
+        `)
+        .eq("visto", false)
+        .order("updated_at", { ascending: false })
+        .limit(10);
+
+    if (error) console.error("getNotificaciones:", error);
+    const normalizado = (data ?? []).map(row => ({
+        ...row,
+        pacientes: Array.isArray(row.pacientes)
+            ? (row.pacientes[0] ?? null)
+            : row.pacientes,
+    }));
+    return normalizado as unknown as Notificacion[];
+}
+
+export async function getUsuariosRecientes(astroContext: Parameters<typeof clerkClient>[0]) {
+    try {
+        const client   = clerkClient(astroContext);
+        const response = await client.users.getUserList({
+            limit:   10,
+            orderBy: "-last_active_at",
+        });
+        return Array.isArray(response) ? response : (response.data ?? []);
+    } catch (e) {
+        console.error("getUsuariosRecientes:", e);
+        return [];
+    }
+}
+
+export async function marcarTodasLeidas(): Promise<void> {
+    const { error } = await supabase
+        .from("respuestas_cuestionarios")
+        .update({ visto: true })
+        .eq("visto", false);
+
+    if (error) throw new Error(`marcarTodasLeidas: ${error.message}`);
+}

--- a/src/services/lista-pendientes.service.ts
+++ b/src/services/lista-pendientes.service.ts
@@ -1,0 +1,74 @@
+/**
+ * @file pendientes.service.ts
+ * @description Capa de acceso a datos para el módulo de tareas pendientes.
+ * Cubre lectura de tareas, creación, y marcado como completada.
+ * La lista de personal se obtiene de Clerk desde la página, ya que requiere
+ * el contexto de Astro.
+ */
+
+import { supabase } from "../lib/supabase";
+
+export interface Tarea {
+    id: number;
+    titulo: string;
+    descripcion: string | null;
+    responsable: string;
+    creado_por: string | null;
+    creado_el: string;
+    estado: "pendiente" | "completada" | null;
+    completado_por: string | null;
+    completado_el: string | null;
+}
+
+export async function getTareasDeUsuario(responsable: string): Promise<Tarea[]> {
+    const { data, error } = await supabase
+        .from("tareas_pendientes")
+        .select("id, titulo, descripcion, creado_el")
+        .eq("estado", "pendiente")
+        .eq("responsable", responsable)
+        .order("creado_el", { ascending: false });
+
+    if (error) console.error("getTareasDeUsuario:", error);
+    return (data ?? []) as Tarea[];
+}
+
+export async function getTareasPendientes(): Promise<Tarea[]> {
+    const { data, error } = await supabase
+        .from("tareas_pendientes")
+        .select("*")
+        .eq("estado", "pendiente")
+        .order("creado_el", { ascending: false });
+
+    if (error) console.error("getTareasPendientes:", error);
+    return (data ?? []) as Tarea[];
+}
+
+export async function crearTarea(params: {
+    titulo: string;
+    descripcion: string;
+    responsable: string;
+    creadoPor: string;
+}): Promise<void> {
+    const { error } = await supabase.from("tareas_pendientes").insert({
+        titulo:      params.titulo,
+        descripcion: params.descripcion,
+        responsable: params.responsable,
+        creado_por:  params.creadoPor,
+        estado:      "pendiente",
+    });
+
+    if (error) throw new Error(`crearTarea: ${error.message}`);
+}
+
+export async function completarTarea(idTarea: number, completadoPor: string): Promise<void> {
+    const { error } = await supabase
+        .from("tareas_pendientes")
+        .update({
+            estado:         "completada",
+            completado_por: completadoPor,
+            completado_el:  new Date().toISOString(),
+        })
+        .eq("id", idTarea);
+
+    if (error) throw new Error(`completarTarea: ${error.message}`);
+}


### PR DESCRIPTION
Extract data access into dedicated services and centralize Supabase client.

- Add src/lib/supabase.ts (createClient wrapper).
- Add services: src/services/citas.service.ts, dashboard.service.ts, lista-pendientes.service.ts to handle queries and mutations for citas, dashboard and pendientes.
- Refactor pages to use the new services: src/pages/citas.astro, dashboard.astro, pendientes/lista-pendientes.astro.
- Adjust CitaCard prop type (id: number) and minor UI tweaks (calendar dialog -> div, sidebar tasks added in dashboard).
- Update changelog entry text in src/data/changelog.ts.

Purpose: separate concerns, centralize DB interactions, simplify page handlers and improve type safety.