### PR TITLE
hotfix: Use string IDs for tasks and bump version

### DIFF
--- a/src/data/changelog.ts
+++ b/src/data/changelog.ts
@@ -1,4 +1,4 @@
-export const currentVersion = "3.2.0";
+export const currentVersion = "3.3.1";
 
 export const isMajorUpdate = true;
 

--- a/src/pages/dashboard.astro
+++ b/src/pages/dashboard.astro
@@ -39,7 +39,7 @@ if (Astro.request.method === "POST") {
         }
 
         if (action === "completar_tarea_sidebar") {
-            const idTarea = parseInt(formData.get("id_tarea") as string);
+            const idTarea = formData.get("id_tarea") as string;
             await completarTarea(idTarea, nombreCompleto as string);
         }
     } catch (e) {

--- a/src/pages/pendientes/lista-pendientes.astro
+++ b/src/pages/pendientes/lista-pendientes.astro
@@ -44,7 +44,7 @@ if (Astro.request.method === "POST") {
         }
 
         if (accion === "completar_tarea") {
-            const idTarea = parseInt(data.get("id_tarea") as string);
+            const idTarea = data.get("id_tarea") as string; 
             await completarTarea(idTarea, nombreCreador as string);
         }
 

--- a/src/services/lista-pendientes.service.ts
+++ b/src/services/lista-pendientes.service.ts
@@ -9,7 +9,7 @@
 import { supabase } from "../lib/supabase";
 
 export interface Tarea {
-    id: number;
+    id: string;
     titulo: string;
     descripcion: string | null;
     responsable: string;
@@ -60,7 +60,7 @@ export async function crearTarea(params: {
     if (error) throw new Error(`crearTarea: ${error.message}`);
 }
 
-export async function completarTarea(idTarea: number, completadoPor: string): Promise<void> {
+export async function completarTarea(idTarea: string, completadoPor: string): Promise<void> { // <-- idTarea: string
     const { error } = await supabase
         .from("tareas_pendientes")
         .update({


### PR DESCRIPTION
Change task ID type from number to string across the service and pages: update Tarea.id and completarTarea(idTarea: string) in lista-pendientes.service.ts, and remove parseInt calls in dashboard.astro and lista-pendientes.astro so string IDs are passed through.

Also bump currentVersion to 3.3.0 (isMajorUpdate remains true).

Note: this is a breaking change for callers expecting numeric IDs; adjust any other consumers accordingly.