### PR TITLE
Add 'otro' motivo option for citas

### DIFF
--- a/src/components/CitaCard.astro
+++ b/src/components/CitaCard.astro
@@ -39,6 +39,7 @@ const motivoColors = {
     entrevista: "bg-blue-500/20 text-blue-300 border-blue-500/50",
     seguimiento: "bg-purple-500/20 text-purple-300 border-purple-500/50",
     tratamiento: "bg-emerald-500/20 text-emerald-300 border-emerald-500/50",
+    otro: "bg-amber-500/20 text-amber-300 border-amber-500/50",
     default: "bg-gray-700/50 text-gray-400 border-gray-600"
 };
 

--- a/src/data/changelog.ts
+++ b/src/data/changelog.ts
@@ -1,4 +1,4 @@
-export const currentVersion = "3.6.6";
+export const currentVersion = "3.6.7";
 
 export const isMajorUpdate = false;
 
@@ -12,13 +12,8 @@ type Changes = {
 
 export const changes: Changes[] = [
     {
-        title: "Reportes directos",
-        description: "Ahora se puede generar el reporte directo del expediente del paciente.",
-        type: "feature"
-    },
-    {
-        title: "Reportes mejorados",
-        description: "Se corrigió la primera observación para considerar el tipo de apnea presente.",
-        type: "fix"
+        title: "Tipos de citas",
+        description: "Ahora se puede crear un tipo de cita especial con la etiqueta 'Otro'.",
+        type: "style"
     }
 ];

--- a/src/pages/editar-cita/[id].astro
+++ b/src/pages/editar-cita/[id].astro
@@ -229,6 +229,10 @@ const fechaValue = `${fechaParte}T${horaParte}`;
                             <input type="radio" name="motivo" value="tratamiento" checked={cita.motivo === 'tratamiento'} required class="accent-blue-500 w-5 h-5">
                             <span class="font-medium">Tratamiento</span>
                         </label>
+                        <label class="flex items-center gap-3 cursor-pointer hover:text-blue-400 transition p-2 rounded hover:bg-white/5">
+                            <input type="radio" name="motivo" value="otro" checked={cita.motivo === 'otro'} required class="accent-blue-500 w-5 h-5">
+                            <span class="font-medium">Otro</span>
+                        </label>
                     </div>
 
                     <div class="flex flex-col mt-4">

--- a/src/pages/nueva-cita.astro
+++ b/src/pages/nueva-cita.astro
@@ -179,6 +179,10 @@ const listaInhabiles = await getInhabilesDesdeHoy();
                                 <input type="radio" name="motivo" value="tratamiento" required class="accent-blue-500 w-5 h-5">
                                 <span class="font-medium">Tratamiento</span>
                             </label>
+                            <label class="flex items-center gap-3 cursor-pointer hover:text-blue-400 transition p-2 rounded hover:bg-white/5">
+                                <input type="radio" name="motivo" value="otro" required class="accent-blue-500 w-5 h-5">
+                                <span class="font-medium">Otro</span>
+                            </label>
                         </div>
                     </div>
 


### PR DESCRIPTION
This pull request introduces support for a new "Otro" (Other) appointment type across the application, allowing users to select and visually distinguish this new type when creating or editing appointments. The changelog and version number have also been updated to reflect this addition.

**Appointment Type Enhancements:**

* Added the "otro" (Other) appointment type as a selectable option in both the new appointment (`src/pages/nueva-cita.astro`) and edit appointment (`src/pages/editar-cita/[id].astro`) forms. ([src/pages/nueva-cita.astroR182-R185](diffhunk://#diff-3928e910df7edacc38e45e789bf22dfb578518ff7876cc746f0dd210db74a108R182-R185), [src/pages/editar-cita/[id].astroR232-R235](diffhunk://#diff-cfba12733918f8f0509b27e706b008ddbb950cb6a6a05fc6ab0313a82f4b0548R232-R235))
* Updated the `motivoColors` mapping in `CitaCard.astro` to include a specific color scheme for the "otro" type, ensuring it is visually distinct in the UI.