### PR TITLE
Add sleep graphs page and link

### DIFF
--- a/src/data/changelog.ts
+++ b/src/data/changelog.ts
@@ -1,8 +1,8 @@
-export const currentVersion = "3.8.0";
+export const currentVersion = "3.9.0";
 
 export const isMajorUpdate = true;
 
-export const updateDate = "29 de mayo del 2026";
+export const updateDate = "3 de junio del 2026";
 
 type Changes = {
     title: string;
@@ -12,8 +12,8 @@ type Changes = {
 
 export const changes: Changes[] = [
     {
-        title: "Exportar citas",
-        description: "Ahora es posible exportar citas a Excel filtrando por pendientes o todas.",
+        title: "Graficas de resultados",
+        description: "Ahora es posible visualizar los resultados de los cuestionarios en gráficos por cada paciente.",
         type: "feature"
     }
 ];

--- a/src/pages/paciente/sueno/[id].astro
+++ b/src/pages/paciente/sueno/[id].astro
@@ -704,10 +704,15 @@ const ultimaConfig = sesionesTMS.length > 0 ? sesionesTMS[0] : {};
                 <InfoCard title="Puntajes">
                     <div class="flex justify-between items-center mb-6">
                         <p class="text-gray-400 text-sm">Resultados de las pruebas aplicadas al paciente.</p>
-                        <button onclick="document.getElementById('modal-puntajes').showModal()" class="text-xs bg-blue-600 hover:bg-blue-500 text-white px-3 py-1.5 rounded-lg transition-colors cursor-pointer flex items-center gap-2">
-                            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" class="w-3 h-3"><path stroke-linecap="round" stroke-linejoin="round" d="m16.862 4.487 1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L10.582 16.07a4.5 4.5 0 0 1-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 0 1 1.13-1.897l8.932-8.931Zm0 0L19.5 7.125M18 14v4.75A2.25 2.25 0 0 1 15.75 21H5.25A2.25 2.25 0 0 1 3 18.75V8.25A2.25 2.25 0 0 1 5.25 6H10" /></svg>
-                            Gestionar Puntajes
-                        </button>
+                        <div class="flex gap-2">
+                            <button onclick="document.getElementById('modal-puntajes').showModal()" class="text-xs bg-blue-600 hover:bg-blue-500 text-white px-3 py-1.5 rounded-lg transition-colors cursor-pointer flex items-center gap-2">
+                                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" class="w-3 h-3"><path stroke-linecap="round" stroke-linejoin="round" d="m16.862 4.487 1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L10.582 16.07a4.5 4.5 0 0 1-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 0 1 1.13-1.897l8.932-8.931Zm0 0L19.5 7.125M18 14v4.75A2.25 2.25 0 0 1 15.75 21H5.25A2.25 2.25 0 0 1 3 18.75V8.25A2.25 2.25 0 0 1 5.25 6H10" /></svg>
+                                Gestionar Puntajes
+                            </button>
+                            <a href={`/paciente/sueno/${paciente.id}/graficas`} class="text-xs bg-blue-600 hover:bg-blue-500 text-white border border-blue-500/30 px-3 py-1.5 rounded-lg transition-colors cursor-pointer flex items-center gap-2">
+                                Ver Análisis Gráfico
+                            </a>
+                        </div>
                     </div>
     
                     <div class="overflow-x-auto">

--- a/src/pages/paciente/sueno/[id]/graficas.astro
+++ b/src/pages/paciente/sueno/[id]/graficas.astro
@@ -1,0 +1,231 @@
+---
+import Layout from "../../../../layouts/Layout.astro"
+import ReturnButton from "../../../../components/ReturnButton.astro"
+import { createClient } from "@supabase/supabase-js"
+
+const { id } = Astro.params;
+const supabase = createClient(
+    import.meta.env.PUBLIC_SUPABASE_URL,
+    import.meta.env.SUPABASE_KEY
+);
+
+if (!id) return Astro.redirect("/lista");
+
+const { data: paciente, error: errorPaciente } = await supabase
+    .from('pacientes')
+    .select('nombre')
+    .eq('id', id)
+    .single();
+
+if (errorPaciente || !paciente) return Astro.redirect("/lista");
+
+const { data: respuestas } = await supabase
+    .from('respuestas_cuestionarios')
+    .select('fase, cuestionario, datos')
+    .eq('paciente_id', id)
+    .in('cuestionario', ['epworth', 'psqi', 'berlin']);
+
+type FaseData = number | null;
+type PSQIData = (number | null)[];
+
+const chartData = {
+    epworth: { pre: null as FaseData, inter: null as FaseData, post: null as FaseData },
+    berlin: { pre: null as FaseData, inter: null as FaseData, post: null as FaseData },
+    psqi: { 
+        pre: Array(7).fill(null) as PSQIData,
+        inter: Array(7).fill(null) as PSQIData,
+        post: Array(7).fill(null) as PSQIData
+    }
+};
+
+if (respuestas) {
+    respuestas.forEach(resp => {
+        const { fase, cuestionario, datos } = resp;
+        const faseKey = fase as 'pre' | 'inter' | 'post';
+        
+        if (cuestionario === 'epworth') {
+            chartData.epworth[faseKey] = datos.puntaje ?? null;
+        }
+        
+        if (cuestionario === 'berlin') {
+            chartData.berlin[faseKey] = datos.puntaje ?? null;
+        }
+        
+        if (cuestionario === 'psqi') {
+            chartData.psqi[faseKey] = [
+                parseInt(datos["C1 Calidad"]) || 0,
+                parseInt(datos["C2 Latencia"]) || 0,
+                parseInt(datos["C3 Duración"]) || 0,
+                parseInt(datos["C4 Eficiencia"]) || 0,
+                parseInt(datos["C5 Perturbaciones"]) || 0,
+                parseInt(datos["C6 Medicación"]) || 0,
+                parseInt(datos["C7 Disfunción"]) || 0
+            ];
+        }
+    });
+}
+---
+
+<Layout title={`${paciente.nombre}`}>
+    <ReturnButton href={`/paciente/sueno/${id}`} text="Volver al Expediente" />
+
+    <main class="max-w-6xl mx-auto pt-10 pb-28 px-4">
+        
+        <div class="border-b-2 border-white/10 pb-6 mb-10">
+            <p class="text-indigo-400 text-sm font-bold uppercase tracking-widest mb-2">Epworth, PSQI, Berlín</p>
+            <h1 class="text-4xl md:text-5xl font-extrabold capitalize text-white">{paciente.nombre}</h1>
+            <p class="text-gray-400 mt-3 text-sm">Evolución de puntajes médicos a través de las fases de tratamiento.</p>
+        </div>
+
+        <div class="grid grid-cols-1 lg:grid-cols-2 gap-8 mb-8">
+            <div class="bg-slate-50 p-6 rounded-2xl shadow-lg border border-gray-200">
+                <div class="mb-4">
+                    <h2 class="text-lg font-bold text-gray-800 uppercase tracking-wider">Escala de Epworth</h2>
+                    <p class="text-xs text-gray-700">Severidad de Somnolencia Diurna (0 - 24 pts)</p>
+                </div>
+                <div class="relative h-64 w-full">
+                    <canvas id="chart-epworth"></canvas>
+                </div>
+            </div>
+
+            <div class="bg-white p-6 rounded-2xl shadow-lg border border-gray-200">
+                <div class="mb-4">
+                    <h2 class="text-lg font-bold text-gray-800 uppercase tracking-wider">Cuestionario Berlín</h2>
+                    <p class="text-xs text-gray-700">Categorías de Riesgo Positivas (0 - 3)</p>
+                </div>
+                <div class="relative h-64 w-full">
+                    <canvas id="chart-berlin"></canvas>
+                </div>
+            </div>
+        </div>
+
+        <div class="bg-white p-6 rounded-2xl shadow-lg border border-gray-200">
+            <div class="mb-4">
+                <h2 class="text-lg font-bold text-gray-800 uppercase tracking-wider">Calidad de Sueño PSQI</h2>
+                <p class="text-xs text-gray-700">Desglose de los 7 componentes evaluados (0 - 3 pts por componente)</p>
+            </div>
+            <div class="relative h-80 w-full">
+                <canvas id="chart-psqi"></canvas>
+            </div>
+        </div>
+    </main>
+</Layout>
+
+<script is:inline src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+<script define:vars={{ chartData }}>
+    document.addEventListener('DOMContentLoaded', () => {
+        Chart.defaults.color = '#000000'; 
+        Chart.defaults.font.family = "DM Serif Text, system-ui, sans-serif";
+        Chart.defaults.scale.grid.color = 'rgba(0, 0, 0, 0.25)';
+        
+        Chart.defaults.plugins.tooltip.backgroundColor = 'rgba(15, 23, 42, 0.9)'; 
+        Chart.defaults.plugins.tooltip.titleColor = '#ffffff';
+        Chart.defaults.plugins.tooltip.padding = 10;
+        Chart.defaults.plugins.tooltip.cornerRadius = 8;
+        
+        Chart.defaults.plugins.legend.labels.usePointStyle = true;
+        Chart.defaults.plugins.legend.labels.padding = 20;
+
+        const colors = {
+            pre: { bg: 'rgba(59, 130, 246, 0.8)', border: 'rgb(37, 99, 235)' },    
+            inter: { bg: 'rgba(168, 85, 247, 0.8)', border: 'rgb(147, 51, 234)' },  
+            post: { bg: 'rgba(16, 185, 129, 0.8)', border: 'rgb(5, 150, 105)' }     
+        };
+
+        new Chart(document.getElementById('chart-epworth'), {
+            type: 'bar',
+            data: {
+                labels: ['Pre-Tx', 'Inter', 'Post-Tx'],
+                datasets: [{
+                    label: 'Puntaje Epworth',
+                    data: [chartData.epworth.pre, chartData.epworth.inter, chartData.epworth.post],
+                    backgroundColor: [colors.pre.bg, colors.inter.bg, colors.post.bg],
+                    borderColor: [colors.pre.border, colors.inter.border, colors.post.border],
+                    borderWidth: 1,
+                    borderRadius: 6,
+                    barPercentage: 0.6
+                }]
+            },
+            options: {
+                responsive: true,
+                maintainAspectRatio: false,
+                plugins: { legend: { display: false } },
+                scales: {
+                    y: { beginAtZero: true, max: 24, ticks: { stepSize: 6 } },
+                    x: { grid: { display: false } }
+                }
+            }
+        });
+
+        new Chart(document.getElementById('chart-berlin'), {
+            type: 'bar',
+            data: {
+                labels: ['Pre-Tx', 'Inter', 'Post-Tx'],
+                datasets: [{
+                    label: 'Categorías Positivas',
+                    data: [chartData.berlin.pre, chartData.berlin.inter, chartData.berlin.post],
+                    backgroundColor: [colors.pre.bg, colors.inter.bg, colors.post.bg],
+                    borderColor: [colors.pre.border, colors.inter.border, colors.post.border],
+                    borderWidth: 1,
+                    borderRadius: 6,
+                    barPercentage: 0.6
+                }]
+            },
+            options: {
+                responsive: true,
+                maintainAspectRatio: false,
+                plugins: { legend: { display: false } },
+                scales: {
+                    y: { beginAtZero: true, max: 3, ticks: { stepSize: 1 } },
+                    x: { grid: { display: false } }
+                }
+            }
+        });
+
+        new Chart(document.getElementById('chart-psqi'), {
+            type: 'bar',
+            data: {
+                labels: ['C1: Calidad', 'C2: Latencia', 'C3: Duración', 'C4: Eficiencia', 'C5: Perturbaciones', 'C6: Medicación', 'C7: Disfunción'],
+                datasets: [
+                    {
+                        label: 'Pre-Tratamiento',
+                        data: chartData.psqi.pre,
+                        backgroundColor: colors.pre.bg,
+                        borderColor: colors.pre.border,
+                        borderWidth: 1,
+                        borderRadius: 4
+                    },
+                    {
+                        label: 'Intermedio',
+                        data: chartData.psqi.inter,
+                        backgroundColor: colors.inter.bg,
+                        borderColor: colors.inter.border,
+                        borderWidth: 1,
+                        borderRadius: 4
+                    },
+                    {
+                        label: 'Post-Tratamiento',
+                        data: chartData.psqi.post,
+                        backgroundColor: colors.post.bg,
+                        borderColor: colors.post.border,
+                        borderWidth: 1,
+                        borderRadius: 4
+                    }
+                ]
+            },
+            options: {
+                responsive: true,
+                maintainAspectRatio: false,
+                scales: {
+                    y: { 
+                        beginAtZero: true, 
+                        max: 3, 
+                        ticks: { stepSize: 1 },
+                        title: { display: true, text: 'Nivel de severidad (0-3)' }
+                    },
+                    x: { grid: { display: false } }
+                }
+            }
+        });
+    });
+</script>


### PR DESCRIPTION
This pull request introduces a major new feature for visualizing patient questionnaire results with interactive charts, and enhances the patient results page with a direct link to the new graphical analysis. The most important changes are grouped below:

**New Feature: Graphical Analysis of Questionnaire Results**
- Added a new page (`src/pages/paciente/sueno/[id]/graficas.astro`) that displays interactive charts for Epworth, PSQI, and Berlin questionnaires, showing patient scores across treatment phases using Chart.js. The page fetches and processes data from Supabase and presents it in a user-friendly visual format. ([src/pages/paciente/sueno/[id]/graficas.astroR1-R231](diffhunk://#diff-248568c53bcffb1459759fa4c3dcc5acec4871abd1a0ddd9ec3819d4eacd74b5R1-R231))

**User Interface Enhancements**
- Updated the patient results page (`src/pages/paciente/sueno/[id].astro`) to include a new "Ver Análisis Gráfico" button, allowing users to quickly access the new graphical analysis page for each patient. ([src/pages/paciente/sueno/[id].astroR707-R715](diffhunk://#diff-1ab0005399e0a2bcdb999e66ab9175677e9d87a80fc32944f64d9250453703ebR707-R715))