### PR TITLE
Add session-number input and filter tasks

### DIFF
--- a/src/data/changelog.ts
+++ b/src/data/changelog.ts
@@ -1,8 +1,8 @@
-export const currentVersion = "3.9.0";
+export const currentVersion = "3.10.0";
 
 export const isMajorUpdate = true;
 
-export const updateDate = "3 de junio del 2026";
+export const updateDate = "15 de junio del 2026";
 
 type Changes = {
     title: string;
@@ -12,8 +12,8 @@ type Changes = {
 
 export const changes: Changes[] = [
     {
-        title: "Graficas de resultados",
-        description: "Ahora es posible visualizar los resultados de los cuestionarios en gráficos por cada paciente.",
+        title: "Numeración de citas",
+        description: "Ahora es posible enumerar las citas creadas por grupos.",
         type: "feature"
     }
 ];

--- a/src/pages/multiples-citas.astro
+++ b/src/pages/multiples-citas.astro
@@ -256,6 +256,11 @@ const opcionesReferencia = [
                         </div>
                     </div>
 
+                    <div>
+                        <label class="block text-xs font-semibold uppercase tracking-wider text-gray-500 mb-1.5">Número de Sesión Inicial</label>
+                        <input type="number" id="campo-sesion-inicial" min="1" placeholder="Ej. 1, 4 (Opcional)" class="w-full p-3 border border-gray-700 bg-gray-900/50 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 text-white placeholder-gray-500 transition-all text-sm" />
+                    </div>
+
                     <div class="md:col-span-2">
                         <label class="block text-xs font-semibold uppercase tracking-wider text-gray-500 mb-1.5">Observaciones</label>
                         <input type="text" id="campo-observaciones" placeholder="Opcional" class="w-full p-3 border border-gray-700 bg-gray-900/50 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 text-white placeholder-gray-500 transition-all text-sm" />
@@ -509,8 +514,21 @@ const opcionesReferencia = [
 
         const getVal = (id) => document.getElementById(`campo-${id}`).value.trim();
         const lote = [];
+        
+        const numInicialStr = document.getElementById("campo-sesion-inicial").value;
+        let numContador = numInicialStr ? parseInt(numInicialStr) : null;
 
-        Array.from(fechasSeleccionadas).forEach(fecha => {
+        const fechasOrdenadas = Array.from(fechasSeleccionadas).sort();
+
+        fechasOrdenadas.forEach(fecha => {
+            let obsFinal = getVal("observaciones");
+
+            if (numContador !== null) {
+                const textoSesion = `Sesión #${numContador}`;
+                obsFinal = obsFinal ? `${textoSesion} | ${obsFinal}` : textoSesion;
+                numContador++;
+            }
+
             lote.push({
                 nombre:        getVal("nombre"),
                 telefono:      getVal("telefono") || null,
@@ -518,7 +536,7 @@ const opcionesReferencia = [
                 referencia:    getVal("referencia"),
                 motivo:        getVal("motivo"),
                 fechaLocal:    `${fecha}T${horaSeleccionada}`,
-                observaciones: getVal("observaciones") || null,
+                observaciones: obsFinal || null,
                 atendidoPor:   getVal("atendido_por"),
                 servicio:      servicioActual,
             });

--- a/src/pages/pendientes/lista-pendientes.astro
+++ b/src/pages/pendientes/lista-pendientes.astro
@@ -55,7 +55,7 @@ if (Astro.request.method === "POST") {
     return Astro.redirect("/pendientes/lista-pendientes");
 }
 
-const tareas = await getTareasPendientes();
+const tareas = await getTareasPendientes(currentUser?.id);
 
 const getInitials = (name: string) => {
     if (!name) return "?";

--- a/src/services/lista-pendientes.service.ts
+++ b/src/services/lista-pendientes.service.ts
@@ -32,7 +32,13 @@ export async function getTareasDeUsuario(responsable: string): Promise<Tarea[]> 
     return (data ?? []) as Tarea[];
 }
 
-export async function getTareasPendientes(): Promise<Tarea[]> {
+export async function getTareasPendientes(userIdIdClerk?: string): Promise<Tarea[]> {
+    const LISTA_NEGRA = import.meta.env.ID_RESTRINGIDO;
+
+    if (userIdIdClerk === LISTA_NEGRA) {
+        return [];
+    }
+
     const { data, error } = await supabase
         .from("tareas_pendientes")
         .select("*")


### PR DESCRIPTION
This pull request introduces enhancements to the appointment scheduling and pending tasks features. The main updates include adding support for specifying an initial session number when creating multiple appointments, and restricting access to pending tasks for certain users based on their ID. The changes also ensure that session numbers are incremented and reflected in the appointment notes, and that the pending tasks list is filtered according to the current user.

Appointment scheduling improvements:

* Added an optional "Número de Sesión Inicial" (`campo-sesion-inicial`) input field to the multi-appointment form, allowing users to specify the starting session number. When provided, each appointment created will have its session number incremented and included in the `observaciones` field. (`src/pages/multiples-citas.astro`) [[1]](diffhunk://#diff-fee86ab407ab8d9679b0e2a85bbaf0063427be420f5bfaaeec2fabe72b00e779R259-R263) [[2]](diffhunk://#diff-fee86ab407ab8d9679b0e2a85bbaf0063427be420f5bfaaeec2fabe72b00e779L513-R539)

Pending tasks access control:

* Modified the `getTareasPendientes` service to accept an optional user ID and return an empty list if the user is in a restricted list (based on an environment variable), effectively blocking access for those users. (`src/services/lista-pendientes.service.ts`)
* Updated the pending tasks page to pass the current user's ID to `getTareasPendientes`, ensuring that the task list is filtered appropriately. (`src/pages/pendientes/lista-pendientes.astro`)